### PR TITLE
Added tiny install section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ To use with PostgreSQL, set the following:
     meddler.Placeholder = "$1"
     meddler.PostgreSQL = true
 
+Install
+-------
+
+The usual `go get` command will put it in your `$GOPATH`:
+
+    go get github.com/russross/meddler
 
 Why?
 ----


### PR DESCRIPTION
Mostly so I can copy/paste the go get command from the README.
