### PR TITLE
added meddler to encrypt and decrypt database values

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,9 @@ includes:
 
 *   gobgzip: same, but compresses using gzip on save, and
     uncompresses on load
+
+*   gobgencrypt: same, but encrypts using a block cipher on save, and
+    decrypts on load
     
 You can implement custom meddlers as well by implementing the
 Meddler interface. See the existing implementations in medder.go for
@@ -303,6 +306,14 @@ If you need a different database, create your own Database instance
 with the appropriate parameters set. If everything works okay,
 please contact me with the parameters you used so I can add the new
 database to the pre-defined list.
+
+Working with Encryption
+-----------------------
+
+If you are using a meddler to ecrypt or decrypt field values, you
+must set the DefaultCipher:
+
+    meddler.DefaultCipher = aes.NewCipher(...)
 
 
 Lower-level functions

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ includes:
 *   gobgzip: same, but compresses using gzip on save, and
     uncompresses on load
 
-*   gobgencrypt: same, but encrypts using a block cipher on save, and
+*   gobencrypt: same, but encrypts using a block cipher on save, and
     decrypts on load
     
 You can implement custom meddlers as well by implementing the

--- a/meddler.go
+++ b/meddler.go
@@ -3,9 +3,12 @@ package meddler
 import (
 	"bytes"
 	"compress/gzip"
+	"crypto/cipher"
+	"crypto/rand"
 	"encoding/gob"
 	"encoding/json"
 	"fmt"
+	"io"
 	"reflect"
 	"time"
 )
@@ -50,8 +53,9 @@ func init() {
 	Register("zeroisnull", ZeroIsNullMeddler(false))
 	Register("json", JSONMeddler(false))
 	Register("jsongzip", JSONMeddler(true))
-	Register("gob", GobMeddler(false))
-	Register("gobgzip", GobMeddler(true))
+	Register("gob", GobMeddler{false, false})
+	Register("gobgzip", GobMeddler{true, false})
+	Register("gobencrypt", GobMeddler{false, true})
 }
 
 // IdentityMeddler is the default meddler, and it passes the original value through with
@@ -279,21 +283,27 @@ func (zip JSONMeddler) PreWrite(field interface{}) (saveValue interface{}, err e
 	return buffer.Bytes(), nil
 }
 
-type GobMeddler bool
+// Default Cipher used to encrypt and decrypt data.
+var DefaultCipher cipher.Block
 
-func (zip GobMeddler) PreRead(fieldAddr interface{}) (scanTarget interface{}, err error) {
+type GobMeddler struct {
+	Zip     bool
+	Encrypt bool
+}
+
+func (elt GobMeddler) PreRead(fieldAddr interface{}) (scanTarget interface{}, err error) {
 	// give a pointer to a byte buffer to grab the raw data
 	return new([]byte), nil
 }
 
-func (zip GobMeddler) PostRead(fieldAddr, scanTarget interface{}) error {
+func (elt GobMeddler) PostRead(fieldAddr, scanTarget interface{}) error {
 	ptr := scanTarget.(*[]byte)
 	if ptr == nil {
 		return fmt.Errorf("GobMeddler.PostRead: nil pointer")
 	}
 	raw := *ptr
 
-	if zip {
+	if elt.Zip {
 		// un-gzip and decode gob
 		gzipReader, err := gzip.NewReader(bytes.NewReader(raw))
 		if err != nil {
@@ -311,6 +321,18 @@ func (zip GobMeddler) PostRead(fieldAddr, scanTarget interface{}) error {
 		return nil
 	}
 
+	if elt.Encrypt {
+		if DefaultCipher == nil {
+			return fmt.Errorf("Gob decrypt error, DefaultCipher is nil")
+		}
+		// decrypt value for gob decoding
+		var err error
+		raw, err = decrypt(DefaultCipher, raw)
+		if err != nil {
+			return fmt.Errorf("Gob decryption error: %v", err)
+		}
+	}
+
 	// decode gob
 	gobDecoder := gob.NewDecoder(bytes.NewReader(raw))
 	if err := gobDecoder.Decode(fieldAddr); err != nil {
@@ -320,10 +342,10 @@ func (zip GobMeddler) PostRead(fieldAddr, scanTarget interface{}) error {
 	return nil
 }
 
-func (zip GobMeddler) PreWrite(field interface{}) (saveValue interface{}, err error) {
+func (elt GobMeddler) PreWrite(field interface{}) (saveValue interface{}, err error) {
 	buffer := new(bytes.Buffer)
 
-	if zip {
+	if elt.Zip {
 		// gob encode and gzip
 		gzipWriter := gzip.NewWriter(buffer)
 		defer gzipWriter.Close()
@@ -338,10 +360,71 @@ func (zip GobMeddler) PreWrite(field interface{}) (saveValue interface{}, err er
 		return buffer.Bytes(), nil
 	}
 
+	if elt.Encrypt {
+		if DefaultCipher == nil {
+			return nil, fmt.Errorf("Gob decryption error, DefaultCipher is nil")
+		}
+		// gob encode
+		gobEncoder := gob.NewEncoder(buffer)
+		if err := gobEncoder.Encode(field); err != nil {
+			return nil, fmt.Errorf("Gob encoding error: %v", err)
+		}
+		// and then ecrypt
+		encrypted, err := encrypt(DefaultCipher, buffer.Bytes())
+		if err != nil {
+			return nil, fmt.Errorf("Gob decryption error: %v", err)
+		}
+
+		return encrypted, nil
+	}
+
 	// gob encode
 	gobEncoder := gob.NewEncoder(buffer)
 	if err := gobEncoder.Encode(field); err != nil {
 		return nil, fmt.Errorf("Gob encoding error: %v", err)
 	}
 	return buffer.Bytes(), nil
+}
+
+func encrypt(block cipher.Block, v []byte) ([]byte, error) {
+	value := make([]byte, len(v))
+	copy(value, v)
+
+	// Generate a random initialization vector
+	iv := generateRandomKey(block.BlockSize())
+	if len(iv) != block.BlockSize() {
+		return nil, fmt.Errorf("Could not generate a valid initialization vector for encryption")
+	}
+
+	// Encrypt it.
+	stream := cipher.NewCTR(block, iv)
+	stream.XORKeyStream(value, value)
+
+	// Return iv + ciphertext.
+	return append(iv, value...), nil
+}
+
+// decrypt a slice of bytes using the specified cipher (encryption algorithm)
+func decrypt(block cipher.Block, value []byte) ([]byte, error) {
+	size := block.BlockSize()
+	if len(value) > size {
+		// Extract iv.
+		iv := value[:size]
+		// Extract ciphertext.
+		value = value[size:]
+		// Decrypt it.
+		stream := cipher.NewCTR(block, iv)
+		stream.XORKeyStream(value, value)
+		return value, nil
+	}
+	return nil, fmt.Errorf("Could not decrypt the value")
+}
+
+// GenerateRandomKey creates a random key of size length bytes
+func generateRandomKey(strength int) []byte {
+	k := make([]byte, strength)
+	if _, err := io.ReadFull(rand.Reader, k); err != nil {
+		return nil
+	}
+	return k
 }

--- a/scan_test.go
+++ b/scan_test.go
@@ -65,7 +65,8 @@ const schema1 = `create table person (
 const schema2 = `create table item (
 	id integer primary key,
 	stuff text not null,
-	stuffz blob not null
+	stuffz blob not null,
+	stuffp blob
 )`
 
 var aliceHeight int = 65


### PR DESCRIPTION
I created a meddler to encrypt and decrypt database values. For many developers security seems to be an afterthought so I thought it might be nice to include this meddler in the default library.

I'm still working on the implementation, but I figured I'd open up a pull request so you could take an early look and let me know if a) you are interested in including this functionality and b) any changes you would like me to make to the implementation