### PR TITLE
Provide a hook function to cache prepared statements

### DIFF
--- a/loadsave.go
+++ b/loadsave.go
@@ -52,7 +52,16 @@ func (d *Database) Load(db DB, table string, dst interface{}, pk int64) error {
 	// run the query
 	q := fmt.Sprintf("SELECT %s FROM %s WHERE %s = %s", columns, d.quoted(table), d.quoted(pkName), d.Placeholder)
 
-	rows, err := db.Query(q, pk)
+	var rows *sql.Rows
+	if StmtCacheFunc != nil {
+		stmt, err := StmtCacheFunc(db, q)
+		if err != nil {
+			return err
+		}
+		rows, err = stmt.Query(pk)
+	} else {
+		rows, err = db.Query(q, pk)
+	}
 	if err != nil {
 		return &dbErr{msg: "meddler.Load: DB error in Query", err: err}
 	}
@@ -98,7 +107,16 @@ func (d *Database) Insert(db DB, table string, src interface{}) error {
 	if d.UseReturningToGetID && pkName != "" {
 		q += " RETURNING " + d.quoted(pkName)
 		var newPk int64
-		err := db.QueryRow(q, values...).Scan(&newPk)
+
+		if StmtCacheFunc != nil {
+			stmt, err := StmtCacheFunc(db, q)
+			if err != nil {
+				return err
+			}
+			err = stmt.QueryRow(values...).Scan(&newPk)
+		} else {
+			err = db.QueryRow(q, values...).Scan(&newPk)
+		}
 		if err != nil {
 			return &dbErr{msg: "meddler.Insert: DB error in QueryRow", err: err}
 		}
@@ -106,7 +124,16 @@ func (d *Database) Insert(db DB, table string, src interface{}) error {
 			return fmt.Errorf("meddler.Insert: Error saving updated pk: %v", err)
 		}
 	} else if pkName != "" {
-		result, err := db.Exec(q, values...)
+		var result sql.Result
+		if StmtCacheFunc != nil {
+			stmt, err := StmtCacheFunc(db, q)
+			if err != nil {
+				return err
+			}
+			result, err = stmt.Exec(values...)
+		} else {
+			result, err = db.Exec(q, values...)
+		}
 		if err != nil {
 			return &dbErr{msg: "meddler.Insert: DB error in Exec", err: err}
 		}
@@ -121,7 +148,15 @@ func (d *Database) Insert(db DB, table string, src interface{}) error {
 		}
 	} else {
 		// no primary key, so no need to lookup new value
-		_, err := db.Exec(q, values...)
+		if StmtCacheFunc != nil {
+			stmt, err := StmtCacheFunc(db, q)
+			if err != nil {
+				return err
+			}
+			_, err = stmt.Exec(values...)
+		} else {
+			_, err = db.Exec(q, values...)
+		}
 		if err != nil {
 			return &dbErr{msg: "meddler.Insert: DB error in Exec", err: err}
 		}
@@ -178,7 +213,16 @@ func (d *Database) Update(db DB, table string, src interface{}) error {
 		d.quoted(pkName), ph)
 	values = append(values, pkValue)
 
-	if _, err := db.Exec(q, values...); err != nil {
+	if StmtCacheFunc != nil {
+		stmt, err := StmtCacheFunc(db, q)
+		if err != nil {
+			return err
+		}
+		_, err = stmt.Exec(values...)
+	} else {
+		_, err = db.Exec(q, values...)
+	}
+	if err != nil {
 		return &dbErr{msg: "meddler.Update: DB error in Exec", err: err}
 	}
 
@@ -214,7 +258,18 @@ func Save(db DB, table string, src interface{}) error {
 // result row.
 func (d *Database) QueryRow(db DB, dst interface{}, query string, args ...interface{}) error {
 	// perform the query
-	rows, err := db.Query(query, args...)
+	var rows *sql.Rows
+	var err error
+
+	if StmtCacheFunc != nil {
+		stmt, err := StmtCacheFunc(db, query)
+		if err != nil {
+			return err
+		}
+		rows, err = stmt.Query(args...)
+	} else {
+		rows, err = db.Query(query, args...)
+	}
 	if err != nil {
 		return err
 	}
@@ -232,7 +287,18 @@ func QueryRow(db DB, dst interface{}, query string, args ...interface{}) error {
 // all results rows into dst.
 func (d *Database) QueryAll(db DB, dst interface{}, query string, args ...interface{}) error {
 	// perform the query
-	rows, err := db.Query(query, args...)
+	var rows *sql.Rows
+	var err error
+
+	if StmtCacheFunc != nil {
+		stmt, err := StmtCacheFunc(db, query)
+		if err != nil {
+			return err
+		}
+		rows, err = stmt.Query(args...)
+	} else {
+		rows, err = db.Query(query, args...)
+	}
 	if err != nil {
 		return err
 	}

--- a/scan.go
+++ b/scan.go
@@ -42,6 +42,16 @@ var SQLite = &Database{
 
 var Default = MySQL
 
+// StmtCacheFunc is a function that takes a DB interface and a query string
+// and returns a prepared statement or an error. If the returned statement
+// is not nil and there is no error, the statement is used to execute
+// the query. The statement must be valid to be executed on the provided DB.
+// If an error is returned, it is also returned by the calling function
+// (e.g. Load or Insert) and the query is not executed.
+//
+// The default nil value means that no prepared statement is used.
+var StmtCacheFunc func(DB, string) (*sql.Stmt, error)
+
 func (d *Database) quoted(s string) string {
 	return d.Quote + s + d.Quote
 }


### PR DESCRIPTION
Hi Russ,

I know you mentioned in #4 that you were thinking about a way to add this support, but for my use-case I've used a simple and minimally intrusive solution with a function variable that provides a hook that gets called before every statement is executed (see `StmtCacheFunc` comment in the PR).

It is obviously quite flexible, but personally I've used it like this:

```go
var lruCache *lru.Cache // github.com/hashicorp/golang-lru

func init() {
    var err error
    lruCache, err = lru.NewWithEvict(50, stmtEvicted) // 50 is the max number of statements to cache
    if err != nil {
      // ...
    }
    meddler.StmtCacheFunc = stmtCache
}

func stmtCache(db meddler.DB, q string) (*sql.Stmt, error) {
	switch db := db.(type) {
	case *sql.DB:
		v, ok := lruCache.Get(q)
		if !ok {
			s, err := db.Prepare(q)
			if err != nil {
				return nil, err
			}
			if lruCache.Add(q, s) {
				// a statement has been evicted, can e.g. log if that's interesting
			}
			return s, nil
		}
		return v.(*sql.Stmt), nil

	default:
		// do not prepare statements for transactions - too little reuse
		// to be worth it. (see http://go-database-sql.org/prepared.html)
		return nil, nil
	}
}

// cleanup on cache eviction
func stmtEvicted(k, v interface{}) {
	stmt := v.(*sql.Stmt)
	stmt.Close()
}
```

Would that be something you'd like to add? I could also add the `*meddler.Database` (probably as first argument) in case some people use the same queries for various drivers (although they could use the `meddler.DB` as part of the cache key).

Thanks,
Martin
