### PR TITLE
Transform field names into database columns using func

### DIFF
--- a/scan.go
+++ b/scan.go
@@ -42,6 +42,13 @@ var SQLite = &Database{
 
 var Default = MySQL
 
+// MapperFunc signature. Argument is field name, return value is database column.
+type MapperFunc func(in string) string
+
+// Mapper defines the function to transform struct field names into database columns.
+// Default is strings.TrimSpace, basically a no-op
+var Mapper MapperFunc = strings.TrimSpace
+
 func (d *Database) quoted(s string) string {
 	return d.Quote + s + d.Quote
 }
@@ -114,6 +121,9 @@ func getFields(dstType reflect.Type) (*structData, error) {
 		// the tag can override the field name
 		if len(tag) > 0 && tag[0] != "" {
 			name = tag[0]
+		} else {
+			// use mapper func if field has no explicit tag
+			name = Mapper(f.Name)
 		}
 
 		// check for a meddler


### PR DESCRIPTION
This adds a `meddler.Mapper` package global which accepts a `func(in string) string` function signature. 

The function receives a struct field name and returns the database column, and is only called when the field has no explicit `meddler` tag.

I think this can be useful if you don't want to default to the struct field but would like to use a lowercased or snake-cased version of the field name instead.

For lower-cased field names:
```go
meddler.Mapper = strings.ToLower
```

For snake-cased field names:
```go
meddler.Mapper = func(in string) string {
   runes := []rune(in)

   var out []rune
   for i := 0; i < len(runes); i++ {
      if i > 0 && (unicode.IsUpper(runes[i]) || unicode.IsNumber(runes[i])) && ((i+1 < len(runes) && unicode.IsLower(runes[i+1])) || unicode.IsLower(runes[i-1])) {
         out = append(out, '_')
      }
      out = append(out, unicode.ToLower(runes[i]))
   }

   return string(out)
}
```

This is a non-breaking change, as the Mapper defaults to a no-op string function: `strings.TrimSpace`.

Thoughts?