### PR TITLE
Fix Columns() reference in ColumnsQuoted() (#22)

### DIFF
--- a/scan.go
+++ b/scan.go
@@ -193,7 +193,7 @@ func Columns(src interface{}, includePk bool) ([]string, error) {
 //   `column1`,`column2`,...
 // using Quote as the quote character.
 func (d *Database) ColumnsQuoted(src interface{}, includePk bool) (string, error) {
-	unquoted, err := Columns(src, includePk)
+	unquoted, err := d.Columns(src, includePk)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Closes #22

In `Database.ColumnsQuoted()`, replace call to `Columns()` with call to `Database.Columns()`.